### PR TITLE
adjustments to two tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,11 +46,11 @@ BrokenRecord.configure!(; path="http_record")
     @test 27125 ∈ df.CID   # check that estetrol has estriol as a substructure
     sleep(2.0 * get_recordings)
     df13 = CSV.File(playback(() -> query_substructure(;smarts="[r13]Br", output="CSV"), "smarts.bson")) |> DataFrame  # brominated 13-atom ring structures
-    @test 153064026 ∈ df13.CID
+    @test 118303825 ∈ df13.CID
     # The recommended approach for substructure searches is `query_substructure_pug`
     sleep(5.0 * get_recordings)
     cids13 = playback(() -> query_substructure_pug(;smarts="[r13]Br", poll_interval=10*get_recordings), "smarts_pug.bson")  # brominated 13-atom ring structures, via PUG interface
-    @test 153064026 ∈ cids13
+    @test 118303825 ∈ cids13
 
     # properties
     sleep(5.0 * get_recordings)


### PR DESCRIPTION
The previous CID (153064026) being matched in the test do not exist in the PubChem database. Consequently, when testing on the PubChem website directly instead of using the BrokenRecord files, these tests were failing. With this change tests do not fail anymore, as I replaced the erroneous CID with one that exists in PubChem.

Note: when testing the package on the PubChem database directly some tests still seem to be broken. But I noticed that upgrading the version of HTTP.jl in the Project.toml corrects this, and the tests run smoothly. I'll soon PR an update to the Project.toml