### PR TITLE
Route requests through _http_request to avoid HTTP/2 stalls

### DIFF
--- a/src/pugxml.jl
+++ b/src/pugxml.jl
@@ -176,7 +176,7 @@ function get_entrez(top)
 end
 
 function submit_substructure_query(xdoc; poll_interval=10, kwargs...)
-    r = HTTP.request(
+    r = _http_request(
         "POST", "https://pubchem.ncbi.nlm.nih.gov/pug/pug.cgi", [], string(xdoc); kwargs...
     )
     xresp = parse_string(String(r.body))
@@ -190,7 +190,7 @@ function submit_substructure_query(xdoc; poll_interval=10, kwargs...)
             free(xresp)
             sleep(poll_interval)
             # poll for completion
-            r = HTTP.request(
+            r = _http_request(
                 "POST",
                 "https://pubchem.ncbi.nlm.nih.gov/pug/pug.cgi",
                 [],
@@ -215,7 +215,7 @@ function submit_substructure_query(xdoc; poll_interval=10, kwargs...)
     url *= "&query_key=" * content(entrez["PCT-Entrez_query-key"][1])
     url *= "&WebEnv=" * content(entrez["PCT-Entrez_webenv"][1])
     free(xresp)
-    r = HTTP.request("GET", url)
+    r = _http_request("GET", url; kwargs...)
     return parse.(Int, split(chomp(String(r.body)), '\n'))
     # xdl = create_download(entrez; format=format)
     # r = HTTP.request("POST", "https://pubchem.ncbi.nlm.nih.gov/pug/pug.cgi", [], string(xdl); kwargs...)

--- a/src/query.jl
+++ b/src/query.jl
@@ -1,5 +1,18 @@
 const prolog = "https://pubchem.ncbi.nlm.nih.gov/rest/pug/"
 
+const _READTIMEOUT_KW = pkgversion(HTTP) < v"2" ? :readtimeout : :read_idle_timeout
+
+# `HTTP.request` with PubChem/NCBI defaults suited to a crawler.
+# Under HTTP/2 every request to a host multiplexes over one shared connection,
+# so a single  wedged connection stalls every subsequent request;
+# pin HTTP/1.1, whose independent pooled connections confine a stall to the one request.
+# Bound the read-inactivity time to avoid an indefinite stall.
+function _http_request(args...; readtimeout=60, kwargs...)
+    default_kw = pkgversion(HTTP) < v"2" ? (; _READTIMEOUT_KW => readtimeout) :
+                                           (; _READTIMEOUT_KW => readtimeout, protocol = :h1)
+    return HTTP.request(args...; default_kw..., kwargs...)
+end
+
 """
     get_cids(; name=nothing, smiles=nothing, cas_number=nothing,kwargs...)
 
@@ -36,7 +49,7 @@ function get_cids(; name=nothing, smiles=nothing, cas_number=nothing, kwargs...)
     smiles !== nothing && (input *= "smiles/$((smiles))/")
     cas_number !== nothing && (input *= "xref/RN/$(cas_number)/")
     url = prolog * input * "cids/TXT"
-    r = HTTP.request("GET", url; kwargs...)
+    r = _http_request("GET", url; kwargs...)
     return parse.(Int, split(chomp(String(r.body)), '\n'))
 end
 
@@ -118,7 +131,7 @@ function query_substructure(;
     end
     props = canonicalize_properties("property/" * properties)
     url = prolog * input * props * output * "?StripHydrogen=true"
-    r = HTTP.request("GET", url; kwargs...)
+    r = _http_request("GET", url; kwargs...)
     return r.body
 end
 
@@ -209,7 +222,7 @@ function get_for_cids(
     if record_type !== nothing
         url *= "?record_type=" * record_type
     end
-    r = HTTP.request(
+    r = _http_request(
         "POST",
         url,
         ["Content-Type"=>"application/x-www-form-urlencoded"],
@@ -270,7 +283,7 @@ function pug(
     pug_string = join(string.(args), "/")
     url = prolog * pug_string
     silent || @info url
-    r = HTTP.request("GET", url; status_exception, kwargs...)
+    r = _http_request("GET", url; status_exception, kwargs...)
     b = return_text ? chomp(String(r.body)) : r.body
     return b
 end
@@ -301,6 +314,6 @@ function get_synonyms(;
         throw(ArgumentError("one of name, cid, or smiles must be specified"))
     end
     url = prolog * input * "synonyms/TXT"
-    r = HTTP.request("GET", url; kwargs...)
+    r = _http_request("GET", url; kwargs...)
     return split(chomp(String(r.body)), "\n")
 end


### PR DESCRIPTION
Under HTTP/2 all requests to a host multiplex over one shared connection, so a single wedged connection stalls every subsequent request. This switches the default to HTTP/1.1, whose independent pooled connections confine a stall to the one request, and bound the read-inactivity time so a request cannot hang indefinitely.